### PR TITLE
[Docs] fix missing `'`

### DIFF
--- a/docs/02-app/01-building-your-application/02-data-fetching/01-fetching-caching-and-revalidating.mdx
+++ b/docs/02-app/01-building-your-application/02-data-fetching/01-fetching-caching-and-revalidating.mdx
@@ -240,7 +240,7 @@ If an error is thrown while attempting to revalidate data, the last successfully
 
 `fetch` requests are **not** cached if:
 
-- The `cache: 'no-store` is added to `fetch` requests.
+- The `cache: 'no-store'` is added to `fetch` requests.
 - The `revalidate: 0` option is added to individual `fetch` requests.
 - The `fetch` request is inside a Router Handler that uses the `POST` method.
 - The `fetch` request comes after the usage of `headers` or `cookies`.


### PR DESCRIPTION
In https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#opting-out-of-data-caching a single quote (`'`) is missing.

![CleanShot 2023-08-15 at 17 08 58](https://github.com/williamli/next.js/assets/179761/cd1e1673-a32d-483f-8b36-c7919235a11b)
